### PR TITLE
Add GitHub Actions for Linux x86 and MacOS x86/ARM64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: main
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        ocaml-compiler:
+          - "5.1"
+          - "4.14"
+        os:
+          - ubuntu-latest       # Linux x86_64
+          - macos-latest        # MacOS x86_64
+          - macos-14            # MacOS ARM64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          opam-pin: false
+          opam-depext: false
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune runtest


### PR DESCRIPTION
Using GitHub Actions we can hit 3 OS/arch combinations, Linux/x86_64, MacOS/x86_64 and MacOS/ARM64.
To cover all Tier-1 architectures minus Windows add this project to https://ocaml.ci.dev/